### PR TITLE
fix(notifications): Send client_id when syncing read state

### DIFF
--- a/lib/data/datasources/notification/notification_remote_datasource.dart
+++ b/lib/data/datasources/notification/notification_remote_datasource.dart
@@ -10,7 +10,7 @@ abstract class NotificationRemoteDataSource {
   Future<List<Notification>> getAllNotifications(
       {DateTime? syncedSince, bool? noClientId});
   Future<Notification?> getNotification(int id);
-  Future<Notification> markAsRead(int id, DateTime readAt);
+  Future<Notification> markAsRead(int id, DateTime readAt, {String? clientId});
 }
 
 @Injectable(as: NotificationRemoteDataSource)
@@ -71,11 +71,13 @@ class NotificationRemoteDataSourceImpl implements NotificationRemoteDataSource {
   }
 
   @override
-  Future<Notification> markAsRead(int id, DateTime readAt) async {
-    final response = await dio.put(
+  Future<Notification> markAsRead(int id, DateTime readAt,
+      {String? clientId}) async {
+    final response = await dio.post(
       'notifications/$id/read',
       data: {
         'read_at': formatServerIsoDateTimeString(readAt),
+        if (clientId != null && clientId.isNotEmpty) 'client_id': clientId,
       },
     );
 

--- a/lib/data/sync/notification_sync_handler.dart
+++ b/lib/data/sync/notification_sync_handler.dart
@@ -62,7 +62,11 @@ class NotificationSyncHandler extends SyncTypeHandler<Notification, String, int>
     // For notifications, we typically don't create/update from client
     // But if read_at is updated, we need to sync it
     if (entity.readAt != null && entity.id != null) {
-      return await remoteDataSource.markAsRead(entity.id!, entity.readAt!);
+      return await remoteDataSource.markAsRead(
+        entity.id!,
+        entity.readAt!,
+        clientId: entity.clientId,
+      );
     }
     return entity;
   }


### PR DESCRIPTION
Mark-as-read calls now forward the local client_id and use the existing POST endpoint, so notifications read offline can be linked to their server-side record on next sync instead of staying orphaned.

