### PR TITLE
chore(release): Bump version to 2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.6+5
+version: 2.0.0+6
 environment:
   sdk: ">=3.4.3 <4.0.0"
 


### PR DESCRIPTION
## Summary

Bumps the app version from `1.0.6+5` to `2.0.0+6` in `pubspec.yaml`, aligning the mobile apps with the webservice [v2.0.0-beta.1](https://github.com/trakli/webservice/releases/tag/v2.0.0-beta.1) release (Codename: Ailanthus, first of the tree-name series).

Once merged, the release tag can be created on the merge commit to trigger the Android + iOS release workflow. In CI the build name is derived from the tag, and build numbers come from the stores, so this pubspec bump keeps local and staging builds consistent with the released version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)